### PR TITLE
feat: add raydium strategy structure

### DIFF
--- a/src/raydium/raydium-api.ts
+++ b/src/raydium/raydium-api.ts
@@ -1,0 +1,61 @@
+/**
+ * Lightweight wrapper around the Raydium HTTP API.
+ *
+ * The Raydium API exposes pool, token and trading endpoints that operate on
+ * the Solana blockchain.  Only a very small subset is implemented here to
+ * keep the implementation lightweight.  See the official docs for the full
+ * specification: https://docs.raydium.io/raydium/protocol/developers/api
+ */
+export class RaydiumAPI {
+  // RPC connection details would normally be handled via `@solana/web3.js`.
+  // The dependency is omitted here to keep the template light; strategies can
+  // extend this class and provide a real connection when integrating fully.
+  private rpcEndpoint: string;
+
+  constructor(
+    rpcEndpoint: string = process.env.SOLANA_RPC_ENDPOINT || 'https://api.mainnet-beta.solana.com'
+  ) {
+    this.rpcEndpoint = rpcEndpoint;
+  }
+
+  /**
+   * Fetch basic pool information from Raydium.
+   *
+   * The Raydium API provides a list of liquidity pools via the `/pools` endpoint.
+   * This method returns the raw JSON response to allow strategies to implement
+   * their own filtering logic.
+   */
+  async fetchPools(): Promise<any[]> {
+    const res = await fetch('https://api.raydium.io/v2/sdk/liquidity/mainnet.json');
+    if (!res.ok) throw new Error(`Raydium pool request failed: ${res.status}`);
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  }
+
+  /**
+   * Fetch a token price from Raydium.
+   *
+   * @param mint The mint address of the token on Solana.
+   */
+  async fetchTokenPrice(mint: string): Promise<number | null> {
+    const url = `https://api.raydium.io/v2/main/price?mints=${mint}`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const json = await res.json();
+    const info = json?.[mint];
+    return typeof info?.price === 'number' ? info.price : null;
+  }
+
+  /**
+   * Create and send a transaction to swap tokens through Raydium.
+   *
+   * This is only a placeholder; real implementations will need to build and
+   * sign the transaction according to the Raydium instructions.  The method
+   * returns the transaction signature when successful.
+   */
+  async swap(): Promise<string> {
+    // Placeholder - real implementation would build and send a transaction
+    // using `@solana/web3.js` and Raydium swap instructions.
+    throw new Error('swap() not implemented');
+  }
+}

--- a/src/raydium/raydium-strategy-manager.ts
+++ b/src/raydium/raydium-strategy-manager.ts
@@ -1,0 +1,55 @@
+import { MarketCondition, TradeResult, TradingStrategy } from '../types.js';
+import { BasicRaydiumStrategy } from './strategies/basic-raydium-strategy.js';
+
+/**
+ * Dedicated strategy manager for Raydium based strategies.  This intentionally
+ * mirrors the generic `StrategyManager` but keeps Raydium logic isolated from
+ * GalaChain strategies.
+ */
+export class RaydiumStrategyManager {
+  private strategies: Map<string, TradingStrategy> = new Map();
+  private currentStrategy: string;
+
+  constructor() {
+    // Register built-in strategies
+    const basic = new BasicRaydiumStrategy();
+    this.strategies.set(basic.name, basic);
+    this.currentStrategy = basic.name;
+  }
+
+  /**
+   * Select a strategy to run based on market conditions.  The implementation is
+   * simple for now – it keeps the current strategy if it can activate, otherwise
+   * picks the first available strategy.
+   */
+  async selectStrategy(market: MarketCondition): Promise<string> {
+    const strategy = this.strategies.get(this.currentStrategy);
+    if (strategy && strategy.shouldActivate(market)) {
+      return this.currentStrategy;
+    }
+
+    for (const [name, strat] of this.strategies) {
+      if (strat.shouldActivate(market)) {
+        this.currentStrategy = name;
+        break;
+      }
+    }
+    return this.currentStrategy;
+  }
+
+  async executeCurrentStrategy(): Promise<TradeResult> {
+    const strategy = this.strategies.get(this.currentStrategy);
+    if (!strategy) {
+      throw new Error(`Strategy not found: ${this.currentStrategy}`);
+    }
+    return strategy.execute();
+  }
+
+  addStrategy(strategy: TradingStrategy): void {
+    this.strategies.set(strategy.name, strategy);
+  }
+
+  getCurrentStrategy(): string {
+    return this.currentStrategy;
+  }
+}

--- a/src/raydium/strategies/basic-raydium-strategy.ts
+++ b/src/raydium/strategies/basic-raydium-strategy.ts
@@ -1,0 +1,56 @@
+import { TradingStrategy, MarketCondition, TradeResult } from '../../types.js';
+import { RaydiumAPI } from '../raydium-api.js';
+
+/**
+ * Basic Raydium trading strategy
+ *
+ * This strategy is intentionally minimal and is meant as a starting point for
+ * Raydium based trading on Solana.  It fetches pool data and, when conditions
+ * are met, logs a placeholder trade.  Real trading logic should build on top
+ * of this file.
+ */
+export class BasicRaydiumStrategy implements TradingStrategy {
+  name = 'raydium-basic';
+  minVolumeRequired = 1;
+  maxRisk = 0.5;
+
+  private api: RaydiumAPI;
+
+  constructor(api: RaydiumAPI = new RaydiumAPI()) {
+    this.api = api;
+  }
+
+  shouldActivate(marketCondition: MarketCondition): boolean {
+    // For now the strategy activates in any market where volume is sufficient
+    return marketCondition.volume > this.minVolumeRequired;
+  }
+
+  async execute(): Promise<TradeResult> {
+    try {
+      const pools = await this.api.fetchPools();
+      const pool = pools[0];
+      console.log(`🕳️ Inspecting Raydium pool:`, pool?.name || 'unknown');
+
+      // Placeholder for trading logic.  A real implementation would build a
+      // transaction using pool information and send it via RaydiumAPI.swap().
+      return {
+        success: true,
+        profit: 0,
+        volume: 0,
+        strategy: this.name,
+        pool: pool?.name || 'none',
+        timestamp: Date.now()
+      };
+    } catch (error: any) {
+      return {
+        success: false,
+        profit: 0,
+        volume: 0,
+        strategy: this.name,
+        pool: 'error',
+        timestamp: Date.now(),
+        error: error.message
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Raydium API wrapper and basic strategy
- introduce Raydium strategy manager for Solana-only trading

## Testing
- `npm run build`
- `npm run test:strategies` *(fails: GALACHAIN_PRIVATE_KEY or PRIVATE_KEY must be set in environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a74e297083299f3e47789a4fb1b4